### PR TITLE
Quantity, Price in Float

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,8 +9,8 @@ function total_amt()
   for( let i=0 ; i < data.length ; i++)
   {
     let copy=data[i];
-    let qt=parseInt(copy.quantity);
-    let pri=parseInt(copy.price);
+    let qt=parseFloat(copy.quantity);
+    let pri=parseFloat(copy.price);
     if(isNaN(qt) || isNaN(pri))
       {
         continue;


### PR DESCRIPTION
Quantity can be in float notation as well, so to avoid 1.5 being interpreted as 1 (and hence totalling error), changed parseInt to parseFloat 
To view the changes, add .patch to end of url